### PR TITLE
[PS-455] Implement RDF List and blank node collection syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.3
+- Support RDF List and blank node collection syntactic sugar.
+
 ## 0.1.2
 - Update Jena version to 4.8.0 to address [CVE-2023-22665](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-22665).
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 A companion library to [Flint](https://github.com/yetanalytics/flint) for the direct compilation of Flint data into [Apache Jena](https://jena.apache.org/)-based SPARQL queries and updates.
 
-Uses Flint version [v0.2.1](https://github.com/yetanalytics/flint/releases/tag/v0.2.1).
+Uses Flint version [v0.3.0](https://github.com/yetanalytics/flint/releases/tag/v0.3.0).
 
 ## Installation
 
 ```clojure
-{com.yetanalytics/flint-jena {:mvn/version "0.1.2"
+{com.yetanalytics/flint-jena {:mvn/version "0.1.3"
                               :exclusions [org.clojure/clojure]}}
 ```
 
@@ -72,4 +72,3 @@ Which then outputs the following to `target/bench/query.txt`:
 Copyright © 2022-2024 Yet Analytics, Inc.
 
 Distributed under the Apache License version 2.0.
-

--- a/deps.edn
+++ b/deps.edn
@@ -5,11 +5,9 @@
         org.apache.jena/jena-arq  {:mvn/version "4.8.0"
                                    :exclusions  [org.slf4j/slf4j-api]}
         org.slf4j/slf4j-api       {:mvn/version "1.7.36"}
-        com.yetanalytics/flint    {:git/sha "572555b1cec0285201b19624fc1190e780d8430e"
-                                   :git/url "https://github.com/yetanalytics/flint.git"}
-        #_{:mvn/version "0.2.1"
-           :exclusions  [org.clojure/clojure
-                         org.clojure/clojurescript]}}
+        com.yetanalytics/flint    {:mvn/version "0.3.0"
+                                   :exclusions  [org.clojure/clojure
+                                                 org.clojure/clojurescript]}}
  :aliases
  {:bench {:extra-paths ["src/bench" "dev-resources"]
           :extra-deps  {criterium/criterium

--- a/deps.edn
+++ b/deps.edn
@@ -5,9 +5,11 @@
         org.apache.jena/jena-arq  {:mvn/version "4.8.0"
                                    :exclusions  [org.slf4j/slf4j-api]}
         org.slf4j/slf4j-api       {:mvn/version "1.7.36"}
-        com.yetanalytics/flint    {:mvn/version "0.2.1"
-                                   :exclusions  [org.clojure/clojure
-                                                 org.clojure/clojurescript]}}
+        com.yetanalytics/flint    {:git/sha "572555b1cec0285201b19624fc1190e780d8430e"
+                                   :git/url "https://github.com/yetanalytics/flint.git"}
+        #_{:mvn/version "0.2.1"
+           :exclusions  [org.clojure/clojure
+                         org.clojure/clojurescript]}}
  :aliases
  {:bench {:extra-paths ["src/bench" "dev-resources"]
           :extra-deps  {criterium/criterium

--- a/dev-resources/test-fixtures/query/select/select-15.edn
+++ b/dev-resources/test-fixtures/query/select/select-15.edn
@@ -1,0 +1,3 @@
+;; SELECT with lists
+{:select [?x]
+ :where  [[?s ?p (1 ?x 3 4)]]}

--- a/dev-resources/test-fixtures/query/select/select-16.edn
+++ b/dev-resources/test-fixtures/query/select/select-16.edn
@@ -1,0 +1,7 @@
+;; SELECT with blank node vectors
+{:prefixes {:$    "<http://foo.org/>"
+            :foaf "<http://xmlns.com/foaf/0.1/>"}
+ :select   [?x ?name]
+ :where    [{[:p1 "v"] {:q1 #{"w"}}
+             :xxxxxxxx {:q2 #{[:p2 "v"]}}
+             [:foaf/name ?name :foaf/mbox "<mailto:bar@example.com>"] {}}]}

--- a/dev-resources/test-fixtures/query/select/select-17.edn
+++ b/dev-resources/test-fixtures/query/select/select-17.edn
@@ -1,0 +1,4 @@
+;; SELECT with empty lists and blank node vectors
+{:select [?x ?y]
+ :where  [[() ?x []]
+          [[] ?y ()]]}

--- a/src/main/com/yetanalytics/flint_jena/triple.clj
+++ b/src/main/com/yetanalytics/flint_jena/triple.clj
@@ -91,9 +91,9 @@
 (defprotocol SubjectObject
   "Protocol for triple subjects and objects. This covers RDF Lists,
     blank node collections, and regular nodes."
-  (-head-node [subj-obj]
+  (-head-node [subject-or-object]
     "Return the Node that external Triples should point to..")
-  (-nested-triples [subj-obj]
+  (-nested-triples [subject-or-object]
     "Return any Triples that are nested in the subject or object."))
 
 (extend-protocol SubjectObject
@@ -113,20 +113,24 @@
 
 (defprotocol Predicate
   "Protocol for triple predicates. This covers paths and regular nodes."
-  (-create-triple [pred subj obj]
-    "Create a triple from the subject, predicate, and object"))
+  (-create-triple [predicate subject object]
+    "Create a triple from `subject`, `predicate`, and `object`."))
 
 (extend-protocol Predicate
   Node
-  (-create-triple [p s o]
-    (Triple. s p o))
+  (-create-triple [pred subj obj]
+    (Triple. subj pred obj))
 
   Path
-  (-create-triple [p s o]
-    (TriplePath. s p o)))
+  (-create-triple [pred subj obj]
+    (TriplePath. subj pred obj)))
 
-(defprotocol ASTTriple ; Can't call this "Triple" for obvious reasons
-  (-add-triple! [triple triple-acc]))
+(defprotocol ASTTriple
+  "Protocol for triples (we can't call this \"Triple\" since that would clash
+    with Jena's Triple class)."
+  (-add-triple! [triple triple-acc]
+    "Add `triple` to `triple-acc` (which should be an instance of
+     TripleCollector)."))
 
 (extend-protocol ASTTriple
   Triple

--- a/src/main/com/yetanalytics/flint_jena/triple.clj
+++ b/src/main/com/yetanalytics/flint_jena/triple.clj
@@ -190,24 +190,26 @@
 
 (defmethod ast/ast-node->jena :triple/list
   [{:keys [active-bnode-map] :as opts} [_ list]]
-  (let [bnode-m      (get opts @active-bnode-map)
-        triple-block (ElementPathBlock.)
-        init-node    (new-bnode! bnode-m)]
-    (loop [curr-bnode init-node
-           next-bnode (new-bnode! bnode-m)
-           list       list]
-      (if-some [list-entry (first list)]
-        (let [node         (-head-node list-entry)
-              triples      (-nested-triples list-entry)
-              first-triple (create-triple curr-bnode rdf-first node)
-              rest-triple  (if (some? (second list))
-                             (create-triple curr-bnode rdf-rest next-bnode)
-                             (create-triple curr-bnode rdf-rest rdf-nil))]
-          (add-triple! triple-block first-triple)
-          (add-triple-coll! triple-block triples)
-          (add-triple! triple-block rest-triple)
-          (recur next-bnode (new-bnode! bnode-m) (rest list)))
-        (->RDFList init-node triple-block)))))
+  (if (empty? list)
+    rdf-nil
+    (let [bnode-m      (get opts @active-bnode-map)
+          triple-block (ElementPathBlock.)
+          init-node    (new-bnode! bnode-m)]
+      (loop [curr-bnode init-node
+             next-bnode (new-bnode! bnode-m)
+             list       list]
+        (if-some [list-entry (first list)]
+          (let [node         (-head-node list-entry)
+                triples      (-nested-triples list-entry)
+                first-triple (create-triple curr-bnode rdf-first node)
+                rest-triple  (if (some? (second list))
+                               (create-triple curr-bnode rdf-rest next-bnode)
+                               (create-triple curr-bnode rdf-rest rdf-nil))]
+            (add-triple! triple-block first-triple)
+            (add-triple-coll! triple-block triples)
+            (add-triple! triple-block rest-triple)
+            (recur next-bnode (new-bnode! bnode-m) (rest list)))
+          (->RDFList init-node triple-block))))))
 
 (defmethod ast/ast-node->jena :triple/bnodes
   [{:keys [active-bnode-map] :as opts} [_ po-pairs]]

--- a/src/main/com/yetanalytics/flint_jena/triple.clj
+++ b/src/main/com/yetanalytics/flint_jena/triple.clj
@@ -1,6 +1,8 @@
 (ns com.yetanalytics.flint-jena.triple
   (:require [com.yetanalytics.flint-jena.ast :as ast])
   (:import [org.apache.jena.graph Node Triple]
+           [org.apache.jena.sparql.graph NodeConst]
+           [org.apache.jena.sparql.lang LabelToNodeMap]
            [org.apache.jena.sparql.path Path]
            [org.apache.jena.sparql.core
             BasicPattern
@@ -86,9 +88,27 @@
 ;; Protocols
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defprotocol SubjectObject
+  (-init-node [list-entry])
+  (-triples [list-entry]))
+
+(extend-protocol SubjectObject
+  Node
+  (-init-node [node] node)
+  (-triples [_] []))
+
+(defrecord RDFList [head-node triples]
+  SubjectObject
+  (-init-node [_] head-node)
+  (-triples [_] (triple-element->seq triples)))
+
+(defrecord BlankNodeColl [subject-node triples]
+  SubjectObject
+  (-init-node [_] subject-node)
+  (-triples [_] (triple-element->seq triples)))
+
 (defprotocol Predicate
-  (-create-triple
-    [pred subj obj]))
+  (-create-triple [pred subj obj]))
 
 (extend-protocol Predicate
   Node
@@ -99,7 +119,7 @@
   (-create-triple [p s o]
     (TriplePath. s p o)))
 
-(defprotocol ASTTriple
+(defprotocol ASTTriple ; Can't call this "Triple" for obvious reasons
   (-add-triple! [triple triple-acc]))
 
 (extend-protocol ASTTriple
@@ -117,67 +137,105 @@
 (defn- add-triple! [triple-acc triple]
   (-add-triple! triple triple-acc))
 
+(defn- add-triples! [triple-acc triples]
+  (dorun (map (fn [triple] (add-triple! triple-acc triple))
+              triples)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; AST Methods
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn- new-bnode! ^Node [^LabelToNodeMap bnode-m]
+  (.allocNode bnode-m))
+
 (defn- s->triples [s]
-  (when-not (:triple-coll? (meta s))
-    (throw (ex-info "Subject without predicates or objects is not an RDF list or blank node collecton!"
-                    {:kind    ::illegal-subject
-                     :subject s})))
-  (triple-element->seq (second s)))
+  (or (not-empty (-triples s))
+      (throw (ex-info "Subject without predicates or objects is not an RDF list or blank node collecton!"
+                      {:kind    ::illegal-subject
+                       :subject s}))))
 
 (defn- spo->triples [s p o]
-  (let [s-coll?   (:triple-coll? (meta s))
-        o-coll?   (:triple-coll? (meta o))
-        s-node    (if s-coll? (first s) s)
-        o-node    (if o-coll? (first o) o)
-        s-triples (when s-coll? (triple-element->seq (second s)))
-        o-triples (when o-coll? (triple-element->seq (second o)))]
-    (concat s-triples
-            [(create-triple s-node p o-node)]
-            o-triples)))
+  (let [s-node    (-init-node s)
+        o-node    (-init-node o)
+        s-triples (-triples s)
+        o-triples (-triples o)
+        triple    (create-triple s-node p o-node)]
+    (concat s-triples [triple] o-triples)))
 
 ;; These multimethod dispatches (specifically `:triple/vec` and `triple/nform`)
 ;; return ElementPathBlocks since that is the most general syntax Element that
 ;; can be used in all clauses (WHERE, CONSTRUCT, DELETE, INSERT, etc).
 
+(def rdf-first NodeConst/nodeFirst)
+(def rdf-rest NodeConst/nodeRest)
+(def rdf-nil NodeConst/nodeNil)
+
 (defmethod ast/ast-node->jena :triple/path [_ [_ path]]
   path)
+
+(defmethod ast/ast-node->jena :triple/list
+  [{:keys [active-bnode-map] :as opts} [_ list]]
+  (let [bnode-m      (get opts @active-bnode-map)
+        triple-block (ElementPathBlock.)
+        init-node    (new-bnode! bnode-m)]
+    (loop [curr-bnode init-node
+           next-bnode (new-bnode! bnode-m)
+           list       list]
+      (if-some [list-entry (first list)]
+        (let [node         (-init-node list-entry)
+              triples      (-triples list-entry)
+              first-triple (create-triple curr-bnode rdf-first node)
+              rest-triple  (if (some? (second list))
+                             (create-triple curr-bnode rdf-rest next-bnode)
+                             (create-triple curr-bnode rdf-rest rdf-nil))]
+          (add-triple! triple-block first-triple)
+          (when (not-empty triples)
+            (add-triples! triple-block triples))
+          (add-triple! triple-block rest-triple)
+          (recur next-bnode (.allocNode bnode-m) (rest list)))
+        (->RDFList init-node triple-block)))))
+
+(defmethod ast/ast-node->jena :triple/bnodes
+  [{:keys [active-bnode-map] :as opts} [_ po-pairs]]
+  (let [bnode-m      (get opts @active-bnode-map)
+        triple-block (ElementPathBlock.)
+        subj-node    (new-bnode! bnode-m)]
+    (dorun
+     (for [[p o] po-pairs
+           :let [o-node    (-init-node o)
+                 o-triples (-triples o)
+                 triple    (create-triple subj-node p o-node)]]
+       (do
+         (add-triple! triple-block triple)
+         (when (not-empty o-triples)
+           (add-triples! triple-block o-triples)))))
+    (->BlankNodeColl subj-node triple-block)))
 
 ;; Vectors
 
 (defmethod ast/ast-node->jena :triple.vec/spo [_ [_ [s p o]]]
   (let [triple-block (ElementPathBlock.)
-        triples (spo->triples s p o)]
-    (dorun (map (fn [triple]
-                  (add-triple! triple-block triple))
-                triples))
+        triples      (spo->triples s p o)]
+    (add-triples! triple-block triples)
     triple-block))
 
 (defmethod ast/ast-node->jena :triple.vec/s [_ [_ [s]]]
   (let [triple-block (ElementPathBlock.)
-        triples (s->triples s)]
-    (dorun (map (fn [triple]
-                  (add-triple! triple-block triple))
-                triples))
+        triples      (s->triples s)]
+    (add-triples! triple-block triples)
     triple-block))
 
 ;; Normal Forms
 
 (defmethod ast/ast-node->jena :triple.nform/spo [_ [_ spo-coll]]
-  (let [triple-block (ElementPathBlock.)]
-    (->> spo-coll
-         (mapcat
-          (fn [[s po-coll]]
-            (if (empty? po-coll)
-              (s->triples s)
-              (mapcat (fn [[p o]] (spo->triples s p o)) po-coll))))
-         (map
-          (fn [triple]
-            (add-triple! triple-block triple)))
-         dorun)
+  (let [triple-block (ElementPathBlock.)
+        triples      (mapcat
+                      (fn [[s po-coll]]
+                        (if (empty? po-coll)
+                          (s->triples s)
+                          (mapcat (fn [[p o]] (spo->triples s p o)) po-coll)))
+                      spo-coll)]
+    (add-triples! triple-block triples)
     triple-block))
 
 (defmethod ast/ast-node->jena :triple.nform/po [_ [_ po]]

--- a/src/main/com/yetanalytics/flint_jena/triple.clj
+++ b/src/main/com/yetanalytics/flint_jena/triple.clj
@@ -10,8 +10,7 @@
            [org.apache.jena.sparql.syntax
             ElementPathBlock
             ElementTriplesBlock
-            TripleCollector
-            TripleCollectorMark]))
+            TripleCollector]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Triple Conversion
@@ -89,35 +88,56 @@
 
 (defprotocol Predicate
   (-create-triple
-    [pred subj obj])
-  (-add-triple!
-    [pred subj obj triples]
-    [pred subj obj triples idx]))
+    [pred subj obj]))
 
 (extend-protocol Predicate
   Node
-  (-create-triple
-    [p s o]
+  (-create-triple [p s o]
     (Triple. s p o))
-  (-add-triple!
-    ([p s o ^TripleCollector coll]
-     (.addTriple coll ^Triple (-create-triple p s o)))
-    ([p s o ^TripleCollectorMark coll idx]
-     (.addTriple coll idx ^Triple (-create-triple p s o))))
 
   Path
-  (-create-triple
-    [p s o]
-    (TriplePath. s p o))
-  (-add-triple!
-    ([p s o ^TripleCollector coll]
-     (.addTriplePath coll ^TriplePath (-create-triple p s o)))
-    ([p s o ^TripleCollectorMark coll idx]
-     (.addTriplePath coll idx ^TriplePath (-create-triple p s o)))))
+  (-create-triple [p s o]
+    (TriplePath. s p o)))
+
+(defprotocol ASTTriple
+  (-add-triple! [triple triple-acc]))
+
+(extend-protocol ASTTriple
+  Triple
+  (-add-triple! [triple ^TripleCollector triple-acc]
+    (.addTriple triple-acc triple))
+  
+  TriplePath
+  (-add-triple! [triple-path ^TripleCollector triple-acc]
+    (.addTriplePath triple-acc triple-path)))
+
+(defn- create-triple [subj pred obj]
+  (-create-triple pred subj obj))
+
+(defn- add-triple! [triple-acc triple]
+  (-add-triple! triple triple-acc))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; AST Methods
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- s->triples [s]
+  (when-not (:triple-coll? (meta s))
+    (throw (ex-info "Subject without predicates or objects is not an RDF list or blank node collecton!"
+                    {:kind    ::illegal-subject
+                     :subject s})))
+  (triple-element->seq (second s)))
+
+(defn- spo->triples [s p o]
+  (let [s-coll?   (:triple-coll? (meta s))
+        o-coll?   (:triple-coll? (meta o))
+        s-node    (if s-coll? (first s) s)
+        o-node    (if o-coll? (first o) o)
+        s-triples (when s-coll? (triple-element->seq (second s)))
+        o-triples (when o-coll? (triple-element->seq (second o)))]
+    (concat s-triples
+            [(create-triple s-node p o-node)]
+            o-triples)))
 
 ;; These multimethod dispatches (specifically `:triple/vec` and `triple/nform`)
 ;; return ElementPathBlocks since that is the most general syntax Element that
@@ -129,15 +149,20 @@
 ;; Vectors
 
 (defmethod ast/ast-node->jena :triple.vec/spo [_ [_ [s p o]]]
-  (let [triple-block (ElementPathBlock.)]
-    (-add-triple! p s o triple-block)
+  (let [triple-block (ElementPathBlock.)
+        triples (spo->triples s p o)]
+    (dorun (map (fn [triple]
+                  (add-triple! triple-block triple))
+                triples))
     triple-block))
 
-;; FIXME
-(defmethod ast/ast-node->jena :triple.vec/s [_ [_ [_head block]]]
-  ;; subject is a RDF list or blank node vector, so it is already
-  ;; an TripleCollector/ElementPathBlock
-  block)
+(defmethod ast/ast-node->jena :triple.vec/s [_ [_ [s]]]
+  (let [triple-block (ElementPathBlock.)
+        triples (s->triples s)]
+    (dorun (map (fn [triple]
+                  (add-triple! triple-block triple))
+                triples))
+    triple-block))
 
 ;; Normal Forms
 
@@ -145,38 +170,32 @@
   (let [triple-block (ElementPathBlock.)]
     (->> spo-coll
          (mapcat
-          (fn [[s po-coll]] (map (fn [[p o]] [s p o]) po-coll)))
-         (map-indexed
-          (fn [idx [s p o]] (-add-triple! p s o triple-block idx)))
+          (fn [[s po-coll]]
+            (if (empty? po-coll)
+              (s->triples s)
+              (mapcat (fn [[p o]] (spo->triples s p o)) po-coll))))
+         (map
+          (fn [triple]
+            (add-triple! triple-block triple)))
          dorun)
-    #_(dorun (map-indexed
-            (fn [idx [s p o]] (-add-triple! p s o triple-block idx))
-            spo-coll))
     triple-block))
 
-#_(defmethod ast/ast-node->jena :triple/spo [_ [_ spo]]
-  (mapcat (fn [[s po-coll]]
-            (map (fn [[p o]] [s p o]) po-coll))
-          spo))
-
 (defmethod ast/ast-node->jena :triple.nform/po [_ [_ po]]
-  (mapcat (fn [[p o-coll]]
-            (map (fn [o] [p o]) o-coll))
+  (mapcat (fn [[p o-coll]] (map (fn [o] [p o]) o-coll))
           po))
 
-(defmethod ast/ast-node->jena :triple.nform/po-empty [_ [_ _]]
-  ;; FIXME
-  nil)
+(defmethod ast/ast-node->jena :triple.nform/po-empty [_ _]
+  [])
 
 (defmethod ast/ast-node->jena :triple.nform/o [_ [_ o]]
   o)
 
 ;; Quads
 
-(defmethod ast/ast-node->jena :triple.quad/spo #_:triple/quad-triples
+(defmethod ast/ast-node->jena :triple.quad/spo
   [_opts [_ triple-elements]]
   (triple-elements->basic-pattern triple-elements))
 
-(defmethod ast/ast-node->jena :triple.quad/gspo #_:triple/quads
+(defmethod ast/ast-node->jena :triple.quad/gspo
   [_opts [_ [graph-node triple-bgp]]]
   (basic-pattern->quad-pattern triple-bgp graph-node))

--- a/src/main/com/yetanalytics/flint_jena/update.clj
+++ b/src/main/com/yetanalytics/flint_jena/update.clj
@@ -123,14 +123,6 @@
 ;; Graph Update
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmethod ast/ast-node->jena :triple/quad-triples
-  [_opts [_ triple-elements]]
-  (t/triple-elements->basic-pattern triple-elements))
-
-(defmethod ast/ast-node->jena :triple/quads
-  [_opts [_ [graph-node triple-bgp]]]
-  (t/basic-pattern->quad-pattern triple-bgp graph-node))
-
 ;; Construct quad accumulators (i.e. QuadBlocks -> QuadAcc)
 ;; These are defined in this namespace since QuadAcc/QuadDataAcc are found
 ;; in the sparql.modify.request package, i.e. they're specific to updates.

--- a/src/main/com/yetanalytics/flint_jena/where.clj
+++ b/src/main/com/yetanalytics/flint_jena/where.clj
@@ -186,3 +186,7 @@
 (defmethod ast/ast-node->jena :where/special
   [_ [_ element]]
   element)
+
+(defmethod ast/ast-node->jena :where/triple
+  [_ [_ element]]
+  element)

--- a/src/test/com/yetanalytics/flint_jena/triple_test.clj
+++ b/src/test/com/yetanalytics/flint_jena/triple_test.clj
@@ -17,13 +17,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- make-triple
-  ^Triple [svar pvar ovar]
+  ^Triple [^String svar ^String pvar ^String ovar]
   (Triple/create (NodeFactory/createVariable svar)
                  (NodeFactory/createVariable pvar)
                  (NodeFactory/createVariable ovar)))
 
 (defn- make-inv-path-triple
-  ^TriplePath [svar piri ovar]
+  ^TriplePath [^String svar ^String piri ^String ovar]
   (TriplePath. (NodeFactory/createVariable svar)
                (->> piri
                     NodeFactory/createURI
@@ -32,36 +32,35 @@
                (NodeFactory/createVariable ovar)))
 
 (defn- make-bnode-head-triple
-  ^Triple [bnode pvar ovar]
+  ^Triple [^String bnode ^String pvar ^String ovar]
   (Triple/create (NodeFactory/createBlankNode bnode)
                  (NodeFactory/createVariable pvar)
                  (NodeFactory/createVariable ovar)))
 
 (defn- make-bnode-pointer-triple
-  ^Triple [svar pvar bnode]
+  ^Triple [^String svar ^String pvar ^String bnode]
   (Triple/create (NodeFactory/createVariable svar)
                  (NodeFactory/createVariable pvar)
                  (NodeFactory/createBlankNode bnode)))
 
 (defn- make-rdf-first-triple*
-  ^Triple [bnode bnode-2]
+  ^Triple [^String bnode ^String bnode-2]
   (Triple/create (NodeFactory/createBlankNode bnode)
                  NodeConst/nodeFirst
                  (NodeFactory/createBlankNode bnode-2)))
 
 (defn- make-rdf-first-triple
-  ^Triple [bnode ovar]
+  ^Triple [^String bnode ^String ovar]
   (Triple/create (NodeFactory/createBlankNode bnode)
                  NodeConst/nodeFirst
                  (NodeFactory/createVariable ovar)))
 
 (defn- make-rdf-rest-triple
-  ^Triple
-  ([bnode]
+  (^Triple [^String bnode]
    (Triple/create (NodeFactory/createBlankNode bnode)
                   NodeConst/nodeRest
                   NodeConst/nodeNil))
-  ([bnode bnode-2]
+  (^Triple [^String bnode ^String bnode-2]
    (Triple/create (NodeFactory/createBlankNode bnode)
                   NodeConst/nodeRest
                   (NodeFactory/createBlankNode bnode-2))))
@@ -242,7 +241,7 @@
    :active-bnode-map (atom :blank-node-map)})
 
 (defn triples=
-  [expected actual]
+  [^ElementPathBlock expected actual]
   (.equalTo expected
             (->> actual (s/conform ts/triple-spec) (ast/ast->jena (opt-map)))
             (NodeIsomorphismMap.)))

--- a/src/test/com/yetanalytics/flint_jena/triple_test.clj
+++ b/src/test/com/yetanalytics/flint_jena/triple_test.clj
@@ -175,6 +175,12 @@
     (.addTriple (make-bnode-head-triple "_:b0" "bp" "bq"))
     (.addTriple (make-bnode-head-triple "_:b0" "br" "bs"))))
 
+;; NOTE: Jena, using QueryFactory/create, uses pre-order traversal to
+;; label the blank nodes, while flint-jena uses post-order traversl. The
+;; resulting graphs are isomorphic (which is why tests pass here), but
+;; since Jena allocates variable nodes instead of blank nodes for lists and
+;; bnode colls, equality checks fail in end-to-end thests.
+
 (def triples-list-bnodes-subj
   "```
    ( ?x [ ?y ?z ] ( ?w ) ) .
@@ -238,6 +244,9 @@
 (defn- opt-map []
   {:blank-var-map    (LabelToNodeMap/createVarMap)
    :blank-node-map   (LabelToNodeMap/createBNodeMap)
+   ;; This is set to `:blank-var-map` in production, but we set it to
+   ;; `:blank-node-map` here since otherwise isomorphic graphs will
+   ;; fail the `.equalTo` check.
    :active-bnode-map (atom :blank-node-map)})
 
 (defn triples=

--- a/src/test/com/yetanalytics/flint_jena/triple_test.clj
+++ b/src/test/com/yetanalytics/flint_jena/triple_test.clj
@@ -6,9 +6,15 @@
             [com.yetanalytics.flint-jena])
   (:import [org.apache.jena.graph NodeFactory Triple]
            [org.apache.jena.sparql.core TriplePath]
+           [org.apache.jena.sparql.graph NodeConst]
+           [org.apache.jena.sparql.lang LabelToNodeMap]
            [org.apache.jena.sparql.path PathFactory]
            [org.apache.jena.sparql.syntax ElementPathBlock]
            [org.apache.jena.sparql.util NodeIsomorphismMap]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Triple Creation Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- make-triple
   ^Triple [svar pvar ovar]
@@ -25,47 +31,260 @@
                     PathFactory/pathInverse)
                (NodeFactory/createVariable ovar)))
 
+(defn- make-bnode-head-triple
+  ^Triple [bnode pvar ovar]
+  (Triple/create (NodeFactory/createBlankNode bnode)
+                 (NodeFactory/createVariable pvar)
+                 (NodeFactory/createVariable ovar)))
+
+(defn- make-bnode-pointer-triple
+  ^Triple [svar pvar bnode]
+  (Triple/create (NodeFactory/createVariable svar)
+                 (NodeFactory/createVariable pvar)
+                 (NodeFactory/createBlankNode bnode)))
+
+(defn- make-rdf-first-triple*
+  ^Triple [bnode bnode-2]
+  (Triple/create (NodeFactory/createBlankNode bnode)
+                 NodeConst/nodeFirst
+                 (NodeFactory/createBlankNode bnode-2)))
+
+(defn- make-rdf-first-triple
+  ^Triple [bnode ovar]
+  (Triple/create (NodeFactory/createBlankNode bnode)
+                 NodeConst/nodeFirst
+                 (NodeFactory/createVariable ovar)))
+
+(defn- make-rdf-rest-triple
+  ^Triple
+  ([bnode]
+   (Triple/create (NodeFactory/createBlankNode bnode)
+                  NodeConst/nodeRest
+                  NodeConst/nodeNil))
+  ([bnode bnode-2]
+   (Triple/create (NodeFactory/createBlankNode bnode)
+                  NodeConst/nodeRest
+                  (NodeFactory/createBlankNode bnode-2))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Expected Triples
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def triples-single
+  "```
+   ?s ?p ?o .
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-triple "s" "p" "o"))))
+
+(def triples-single-path
+  "```
+   ?s ^<http://foo.org/bar> ?o .
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriplePath (make-inv-path-triple "s" "http://foo.org/bar" "o"))))
+
+(def triples-multi
+  "?s ?p1 ?o1b ;
+      ?p1 ?o1a ;
+      ?p2 ?o2b ;
+      ?p2 ?o2a ."
+  (doto (ElementPathBlock.)
+    (.addTriple (make-triple "s" "p1" "o1b"))
+    (.addTriple (make-triple "s" "p1" "o1a"))
+    (.addTriple (make-triple "s" "p2" "o2b"))
+    (.addTriple (make-triple "s" "p2" "o2a"))))
+
+(def triples-multi-path
+  "```
+   ?s ^<http://ex.org/1> ?o1b .
+   ?s ^<http://ex.org/1> ?o1a .
+   ?s ^<http://ex.org/2> ?o2b .
+   ?s ~<http://ex.org/2> ?o2a .
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriplePath (make-inv-path-triple "s" "http://ex.org/1" "o1b"))
+    (.addTriplePath (make-inv-path-triple "s" "http://ex.org/1" "o1a"))
+    (.addTriplePath (make-inv-path-triple "s" "http://ex.org/2" "o2b"))
+    (.addTriplePath (make-inv-path-triple "s" "http://ex.org/2" "o2a"))))
+
+(def triples-list-subj
+  "```
+   ( ?s1 ?s2 ) ?p ?o .
+   ```
+   i.e.
+   ```
+   _:b0 rdf:first ?s1 ;
+        rdf:rest  :_b1 .
+   _:b1 rdf:first ?s2 ;
+        rdf:rest rdf:nil .
+   _:b0 ?p ?o
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-rdf-first-triple "_:b0" "s1"))
+    (.addTriple (make-rdf-rest-triple "_:b0" "_:b1"))
+    (.addTriple (make-rdf-first-triple "_:b1" "s2"))
+    (.addTriple (make-rdf-rest-triple "_:b1"))
+    (.addTriple (make-bnode-head-triple "_:b0" "p" "o"))))
+
+(def triples-list-obj
+  "```
+   ?s ?p ?o .
+   ```
+   i.e.
+   ```
+   ?s ?p _:b0 .
+   _:b0 rdf:first ?s1 ;
+        rdf:rest  :_b1 .
+   _:b1 rdf:first ?s2 ;
+        rdf:rest rdf:nil .
+  ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-bnode-pointer-triple "s" "p" "_:b0"))
+    (.addTriple (make-rdf-first-triple "_:b0" "o1"))
+    (.addTriple (make-rdf-rest-triple "_:b0" "_:b1"))
+    (.addTriple (make-rdf-first-triple "_:b1" "o2"))
+    (.addTriple (make-rdf-rest-triple "_:b1"))))
+
+(def triples-bnodes-subj
+  "```
+   [ ?bp ?bq ?br ?bs ] ?p ?o .
+   ```
+   i.e.
+   ```
+   _:b0 ?bp ?bq ;
+        ?br ?bs ;
+        ?p  ?o
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-bnode-head-triple "_:b0" "bp" "bq"))
+    (.addTriple (make-bnode-head-triple "_:b0" "br" "bs"))
+    (.addTriple (make-bnode-head-triple "_:b0" "p" "o"))))
+
+(def triples-bnodes-obj
+  "```
+   ?s ?p [ ?bp ?bq ?br ?bs ]
+   ```
+   i.e.
+   ```
+   ?s ?p _:b0 .
+   _:b0 ?bp ?bq ;
+        ?br ?bs .
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-bnode-pointer-triple "s" "p" "_:b0"))
+    (.addTriple (make-bnode-head-triple "_:b0" "bp" "bq"))
+    (.addTriple (make-bnode-head-triple "_:b0" "br" "bs"))))
+
+(def triples-list-bnodes-subj
+  "```
+   ( ?x [ ?y ?z ] ( ?w ) ) .
+   ```
+   i.e.
+   ```
+   _:b0 rdf:first ?x ;
+        rdf:rest _:b1 .
+   _:b1 rdf:first _:b2 .
+   _:b2 ?y ?z .
+   _:b1 rdf:rest _:b3 .
+   _:b3 rdf:first _:b4 .
+   _:b4 rdf:first ?w .
+   _:b4 rdf:rest rdf:nil .
+   _:b3 rdf:rest rdf:nil .
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-rdf-first-triple "_:b0" "x"))
+    (.addTriple (make-rdf-rest-triple "_:b0" "_:b1"))
+    (.addTriple (make-rdf-first-triple* "_:b1" "_:b2"))
+    (.addTriple (make-bnode-head-triple "_:b2" "y" "z"))
+    (.addTriple (make-rdf-rest-triple "_:b1" "_:b3"))
+    (.addTriple (make-rdf-first-triple* "_:b3" "_:b4"))
+    (.addTriple (make-rdf-first-triple "_:b4" "w"))
+    (.addTriple (make-rdf-rest-triple "_:b4"))
+    (.addTriple (make-rdf-rest-triple "_:b3"))))
+
+(def triples-list-bnodes-obj
+  "```
+   ?s ?p ( ?x [ ?y ?z ] ( ?w ) ) .
+   ```
+   i.e.
+   ```
+   ?s ?p _:b0 .
+   _:b0 rdf:first ?x ;
+        rdf:rest _:b1 .
+   _:b1 rdf:first _:b2 .
+   _:b2 ?y ?z .
+   _:b1 rdf:rest _:b3 .
+   _:b3 rdf:first _:b4 .
+   _:b4 rdf:first ?w .
+   _:b4 rdf:rest rdf:nil .
+   _:b3 rdf:rest rdf:nil .
+   ```"
+  (doto (ElementPathBlock.)
+    (.addTriple (make-bnode-pointer-triple "s" "p" "_:b0"))
+    (.addTriple (make-rdf-first-triple "_:b0" "x"))
+    (.addTriple (make-rdf-rest-triple "_:b0" "_:b1"))
+    (.addTriple (make-rdf-first-triple* "_:b1" "_:b2"))
+    (.addTriple (make-bnode-head-triple "_:b2" "y" "z"))
+    (.addTriple (make-rdf-rest-triple "_:b1" "_:b3"))
+    (.addTriple (make-rdf-first-triple* "_:b3" "_:b4"))
+    (.addTriple (make-rdf-first-triple "_:b4" "w"))
+    (.addTriple (make-rdf-rest-triple "_:b4"))
+    (.addTriple (make-rdf-rest-triple "_:b3"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Triple Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- opt-map []
+  {:blank-var-map    (LabelToNodeMap/createVarMap)
+   :blank-node-map   (LabelToNodeMap/createBNodeMap)
+   :active-bnode-map (atom :blank-node-map)})
+
+(defn triples=
+  [expected actual]
+  (.equalTo expected
+            (->> actual (s/conform ts/triple-spec) (ast/ast->jena (opt-map)))
+            (NodeIsomorphismMap.)))
+
 (deftest triple-test
   (testing "Triple vector test"
-    (is (.equalTo
-         (doto (ElementPathBlock.)
-           (.addTriple (make-triple "s" "p" "o")))
-         (->> '[?s ?p ?o]
-              (s/conform ts/triple-vec-spec)
-              (conj [:triple.vec/spo])
-              (ast/ast->jena {}))
-         (NodeIsomorphismMap.)))
-    (is (.equalTo
-         (doto (ElementPathBlock.)
-           (.addTriplePath (make-inv-path-triple "s" "http://foo.org/bar" "o")))
-         (->> '[?s (inv "<http://foo.org/bar>") ?o]
-              (s/conform ts/triple-vec-spec)
-              (conj [:triple.vec/spo])
-              (ast/ast->jena {}))
-         (NodeIsomorphismMap.))))
+    (is (triples= triples-single
+                  '[?s ?p ?o]))
+    (is (triples= triples-single-path
+                  '[?s (inv "<http://foo.org/bar>") ?o]))
+    (testing "with lists and bnode colls in subject position"
+      (is (triples= triples-list-subj
+                    '[(?s1 ?s2) ?p ?o]))
+      (is (triples= triples-bnodes-subj
+                    '[[?bp ?bq ?br ?bs] ?p ?o]))
+      (is (triples= triples-list-bnodes-subj
+                    '[(?x [?y ?z] (?w))])))
+    (testing "with lists and bnode colls in object position"
+      (is (triples= triples-list-obj
+                    '[?s ?p (?o1 ?o2)]))
+      (is (triples= triples-bnodes-obj
+                    '[?s ?p [?bp ?bq ?br ?bs]]))
+      (is (triples= triples-list-bnodes-obj
+                    '[?s ?p (?x [?y ?z] (?w))]))))
   (testing "Normal form test"
-    ;; TODO: Make tests order-independent
-    (is (.equalTo
-         (doto (ElementPathBlock.)
-           (.addTriple (make-triple "s" "p1" "o1b"))
-           (.addTriple (make-triple "s" "p1" "o1a"))
-           (.addTriple (make-triple "s" "p2" "o2b"))
-           (.addTriple (make-triple "s" "p2" "o2a")))
-         (->> '{?s {?p1 #{?o1a ?o1b}
-                    ?p2 #{?o2a ?o2b}}}
-              (s/conform ts/normal-form-spec)
-              (conj [:triple.nform/spo])
-              (ast/ast->jena {}))
-         (NodeIsomorphismMap.)))
-    (is (.equalTo
-         (doto (ElementPathBlock.)
-           (.addTriplePath (make-inv-path-triple "s" "http://ex.org/1" "o1b"))
-           (.addTriplePath (make-inv-path-triple "s" "http://ex.org/1" "o1a"))
-           (.addTriplePath (make-inv-path-triple "s" "http://ex.org/2" "o2b"))
-           (.addTriplePath (make-inv-path-triple "s" "http://ex.org/2" "o2a")))
-         (->> '{?s {(inv "<http://ex.org/1>") #{?o1a ?o1b}
-                    (inv "<http://ex.org/2>") #{?o2a ?o2b}}}
-              (s/conform ts/normal-form-spec)
-              (conj [:triple.nform/spo])
-              (ast/ast->jena {}))
-         (NodeIsomorphismMap.)))))
+    (is (triples= triples-multi
+                  '{?s {?p1 #{?o1a ?o1b}
+                        ?p2 #{?o2a ?o2b}}}))
+    (is (triples= triples-multi-path
+                  '{?s {(inv "<http://ex.org/1>") #{?o1a ?o1b}
+                        (inv "<http://ex.org/2>") #{?o2a ?o2b}}}))
+    (testing "with lists and bnode colls in subject position"
+      (is (triples= triples-list-subj
+                    '{(?s1 ?s2) {?p #{?o}}}))
+      (is (triples= triples-bnodes-subj
+                    '{[?bp ?bq ?br ?bs] {?p #{?o}}}))
+      (is (triples= triples-list-bnodes-subj
+                    '{(?x [?y ?z] (?w)) {}})))
+    (testing "with lists and bnode colls in object position"
+      (is (triples= triples-list-obj
+                    '{?s {?p #{(?o1 ?o2)}}}))
+      (is (triples= triples-bnodes-obj
+                    '{?s {?p #{[?bp ?bq ?br ?bs]}}}))
+      (is (triples= triples-list-bnodes-obj
+                    '{?s {?p #{(?x [?y ?z] (?w))}}})))))

--- a/src/test/com/yetanalytics/flint_jena/triple_test.clj
+++ b/src/test/com/yetanalytics/flint_jena/triple_test.clj
@@ -32,7 +32,7 @@
            (.addTriple (make-triple "s" "p" "o")))
          (->> '[?s ?p ?o]
               (s/conform ts/triple-vec-spec)
-              (conj [:triple/vec])
+              (conj [:triple.vec/spo])
               (ast/ast->jena {}))
          (NodeIsomorphismMap.)))
     (is (.equalTo
@@ -40,7 +40,7 @@
            (.addTriplePath (make-inv-path-triple "s" "http://foo.org/bar" "o")))
          (->> '[?s (inv "<http://foo.org/bar>") ?o]
               (s/conform ts/triple-vec-spec)
-              (conj [:triple/vec])
+              (conj [:triple.vec/spo])
               (ast/ast->jena {}))
          (NodeIsomorphismMap.))))
   (testing "Normal form test"
@@ -54,7 +54,7 @@
          (->> '{?s {?p1 #{?o1a ?o1b}
                     ?p2 #{?o2a ?o2b}}}
               (s/conform ts/normal-form-spec)
-              (conj [:triple/nform])
+              (conj [:triple.nform/spo])
               (ast/ast->jena {}))
          (NodeIsomorphismMap.)))
     (is (.equalTo
@@ -66,6 +66,6 @@
          (->> '{?s {(inv "<http://ex.org/1>") #{?o1a ?o1b}
                     (inv "<http://ex.org/2>") #{?o2a ?o2b}}}
               (s/conform ts/normal-form-spec)
-              (conj [:triple/nform])
+              (conj [:triple.nform/spo])
               (ast/ast->jena {}))
          (NodeIsomorphismMap.)))))

--- a/src/test/com/yetanalytics/flint_jena/where_test.clj
+++ b/src/test/com/yetanalytics/flint_jena/where_test.clj
@@ -187,26 +187,26 @@
                               :iri->datatype ax/xsd-datatype-map}))
          (NodeIsomorphismMap.)))))
 
-(def subquery-fix-1
+(def subquery-1
   (QueryFactory/create
    "SELECT ?x ?y ?z WHERE { ?x ?y ?z }"))
 
-(def subquery-fix-2
+(def subquery-2
   (QueryFactory/create
    "SELECT ?x WHERE { ?x ?y ?z } GROUP BY ?x HAVING (?x = ?z)"))
 
-(def subquery-fix-3
+(def subquery-3
   (QueryFactory/create
    "SELECT DISTINCT ?x WHERE { ?x ?y ?z } ORDER BY ASC (?x) LIMIT 100 OFFSET 2"))
 
-(def subquery-fix-4
+(def subquery-4
   (QueryFactory/create
    "SELECT REDUCED ?x ?d WHERE { ?x ?y ?z } VALUES ?d { <http://foo.org/bar> }"))
 
 (deftest subquery-test
   (testing "Subquery"
     (is (.equalTo
-         (ElementSubQuery. subquery-fix-1)
+         (ElementSubQuery. subquery-1)
          (->> '{:select [?x ?y ?z]
                 :where  [[?x ?y ?z]]}
               (s/conform ::ws/where)
@@ -214,7 +214,7 @@
                               :query-stack (atom [(Query. prologue)])}))
          (NodeIsomorphismMap.)))
     (is (.equalTo
-         (ElementSubQuery. subquery-fix-2)
+         (ElementSubQuery. subquery-2)
          (->> '{:select   [?x]
                 :where    [[?x ?y ?z]]
                 :group-by [?x]
@@ -224,7 +224,7 @@
                               :query-stack (atom [(Query. prologue)])}))
          (NodeIsomorphismMap.)))
     (is (.equalTo
-         (ElementSubQuery. subquery-fix-3)
+         (ElementSubQuery. subquery-3)
          (->> '{:select-distinct [?x]
                 :where           [[?x ?y ?z]]
                 :order-by        [(asc ?x)]
@@ -235,7 +235,7 @@
                               :query-stack (atom [(Query. prologue)])}))
          (NodeIsomorphismMap.)))
     (is (.equalTo
-         (ElementSubQuery. subquery-fix-4)
+         (ElementSubQuery. subquery-4)
          (->> '{:select-reduced [?x ?d]
                 :where          [[?x ?y ?z]]
                 :values         {?d ["<http://foo.org/bar>"]}}
@@ -243,7 +243,7 @@
               (ast/ast->jena {:prologue    prologue
                               :query-stack (atom [(Query. prologue)])}))
          (NodeIsomorphismMap.)))
-    (let [subquery (ElementSubQuery. subquery-fix-1)
+    (let [subquery (ElementSubQuery. subquery-1)
           triple   (doto (ElementPathBlock.)
                      (.addTriple bar-triple))
           element  (doto (ElementGroup.)


### PR DESCRIPTION
Update to support RDF list and blank node collection syntactic sugar, which was added to Flint in [this PR](https://github.com/yetanalytics/flint/pull/36). This includes adapting to the internal changes to the AST.